### PR TITLE
Add DELETE endpoint for a specific record in HelpRequest table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
@@ -111,4 +111,22 @@ import java.time.LocalDateTime;
 
         return savedHelpRequest;
     }
+
+    /**
+     * Delete a HelpRequest
+     * 
+     * @param id the id of the helprequest to delete
+     * @return a message indicating the helprequest was deleted
+     */
+    @Operation(summary= "Delete a HelpRequest")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteHelpRequest(
+            @Parameter(name="id") @RequestParam Long id) {
+        HelpRequest helpRequest = helpRequestRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(HelpRequest.class, id));
+
+        helpRequestRepository.delete(helpRequest);
+        return genericMessage("HelpRequest with id %s deleted".formatted(id));
+    }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
@@ -4,6 +4,7 @@ import edu.ucsb.cs156.example.repositories.UserRepository;
 import edu.ucsb.cs156.example.testconfig.TestConfig;
 import edu.ucsb.cs156.example.ControllerTestCase;
 import edu.ucsb.cs156.example.entities.HelpRequest;
+import edu.ucsb.cs156.example.entities.UCSBDate;
 import edu.ucsb.cs156.example.repositories.HelpRequestRepository;
 import edu.ucsb.cs156.example.repositories.UCSBDateRepository;
 
@@ -65,7 +66,6 @@ public class HelpRequestControllerTests extends ControllerTestCase {
         }
 
         // Authorization tests for /api/helprequest/post
-        // (Perhaps should also have these for put and delete)
 
         @Test
         public void logged_out_users_cannot_post() throws Exception {
@@ -79,6 +79,23 @@ public class HelpRequestControllerTests extends ControllerTestCase {
                 mockMvc.perform(post("/api/helprequest/post"))
                                 .andExpect(status().is(403)); // only admins can post
         }
+
+        // Authorization tests for delete
+
+        @Test
+        public void logged_out_users_cannot_delete() throws Exception {
+                mockMvc.perform(delete("/api/helprequest?id=7"))
+                                .andExpect(status().is(403));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_regular_users_cannot_delete() throws Exception {
+                mockMvc.perform(delete("/api/helprequest?id=7"))
+                                .andExpect(status().is(403)); // only admins can post
+        }
+
+        // Functionality tests
         
         @WithMockUser(roles = { "USER" })
         @Test
@@ -203,6 +220,58 @@ public class HelpRequestControllerTests extends ControllerTestCase {
                 Map<String, Object> json = responseToJson(response);
                 assertEquals("EntityNotFoundException", json.get("type"));
                 assertEquals("HelpRequest with id 7 not found", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_delete_a_helprequest() throws Exception {
+                // arrange
+
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+                HelpRequest helpRequest1 = HelpRequest.builder()
+                                .requesterEmail("acdamstedt@ucsb.edu")
+                                .teamID("7")
+                                .tableOrBreakoutRoom("7")
+                                .explanation("Issue!")
+                                .solved(true)
+                                .localDateTime(ldt1)
+                                .build();
+
+                when(helpRequestRepository.findById(eq(15L))).thenReturn(Optional.of(helpRequest1));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/helprequest?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(helpRequestRepository, times(1)).findById(15L);
+                verify(helpRequestRepository, times(1)).delete(any());
+
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("HelpRequest with id 15 deleted", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_tries_to_delete_non_existant_helprequest_and_gets_right_error_message()
+                        throws Exception {
+                // arrange
+
+                when(helpRequestRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/helprequest?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(helpRequestRepository, times(1)).findById(15L);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("HelpRequest with id 15 not found", json.get("message"));
         }
 
 }


### PR DESCRIPTION
Closes #36 
Added delete in HelpRequestController and tests for delete in HelpRequestControllerTests.
Works on localhost and dokku. 100% line/branch coverage and 100% mutation coverage. 
<img width="465" alt="Screenshot 2025-04-23 at 6 51 16 PM" src="https://github.com/user-attachments/assets/3a957b80-62a1-4323-aace-b46d3127142a" />
<img width="900" alt="Screenshot 2025-04-23 at 6 51 34 PM" src="https://github.com/user-attachments/assets/51bef393-a7bb-4720-aa17-303efb15be51" />
